### PR TITLE
change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9.18-slim-bullseye
 
 LABEL "com.github.actions.name"="ChatGPT Reviewer"
 LABEL "com.github.actions.description"="Automated pull requests reviewing and issues triaging with ChatGPT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.18-slim-bullseye
+FROM python:3.11-bullseye
 
 LABEL "com.github.actions.name"="ChatGPT Reviewer"
 LABEL "com.github.actions.description"="Automated pull requests reviewing and issues triaging with ChatGPT"


### PR DESCRIPTION
<img width="1859" alt="image" src="https://github.com/feiskyer/ChatGPT-Reviewer/assets/22561920/63344359-93c8-46a0-8f37-1c9a47f7e9c8">
Gcc is not pre-installed in python:3-alpha, which will cause the image compilation to fail. So change it to python:3.9.18-slim-bullseye